### PR TITLE
Fixed DNS resolution in _check_nameserver

### DIFF
--- a/certbot_dns_active24/dns_active24.py
+++ b/certbot_dns_active24/dns_active24.py
@@ -154,7 +154,7 @@ class _Active24Client(object):
         """
 
         domain, record = self._parse_domain(record_name)
-        logger.debug('Attempting to add record: %s' % record)
+        logger.debug('Attempting to add record %s with content %s' % (record, record_content))
 
         try:
             response = self._send_request('POST', '/dns/%s/txt/v1' % domain, {

--- a/certbot_dns_active24/dns_active24.py
+++ b/certbot_dns_active24/dns_active24.py
@@ -90,13 +90,13 @@ def _wait_for_propagation(challenges):
     while len(queue) > 0:
         queue = [(ns, content, query) for (ns, content, query) in queue if not _check_nameserver(ns, query, content)]
         sleep(1)
-        i += 1
 
         if (i % 30) == 0:
             logger.debug('Remaining records to check: %d' % len(queue))
 
-    signal.signal(signal.SIGUSR1, orig)
+        i += 1
 
+    signal.signal(signal.SIGUSR1, orig)
 
 def _check_nameserver(ns, query, content):
     result = dns.query.udp(query, ns)

--- a/certbot_dns_active24/dns_active24.py
+++ b/certbot_dns_active24/dns_active24.py
@@ -75,7 +75,7 @@ class Authenticator(dns_common.DNSAuthenticator):
 
 def _wait_for_propagation(challenges):
     queue = [(ch.validation_domain_name(ch.domain), ch.validation(ch.account_key)) for ch in challenges]
-    queue = [(o[0], o[1], dns.message.make_query(dns.name.from_text(o[0]), dns.rdatatype.TXT)) for o in queue]
+    queue = [(o[0], o[1], dns.name.from_text(o[0])) for o in queue]
     queue = [(ns, o[1], o[2]) for o in queue for ns in _get_nameservers(o[0])]
 
     logger.debug('Waiting for propagation to authoritative servers')
@@ -99,22 +99,19 @@ def _wait_for_propagation(challenges):
     signal.signal(signal.SIGUSR1, orig)
 
 def _check_nameserver(ns, query, content):
-    result = dns.query.udp(query, ns)
-
     try:
-        # Check only TXT records, because CNAME can be in results if wildcard CNAME record exists.
-        answers = [a for r in result.answer for a in r if a.rdtype == dns.rdatatype.TXT]
-
-        for a in answers:
-            value = ''.join([s.decode('utf-8') for s in a.strings])
-
+        resolver = dns.resolver.Resolver()
+        resolver.nameservers = [ ns ]
+        rrset = resolver.resolve(query, "TXT").rrset
+        for data in rrset:
+            value = data.to_text().strip('"')
             if value == content:
+                logger.debug("found TXT %s in %s" % (value, ns))
                 return True
-    except (KeyError, IndexError):
-        return False
+    except dns.resolver.NXDOMAIN:
+        pass
 
     return False
-
 
 def _get_nameservers(domain):
     resolver = dns.resolver.get_default_resolver()


### PR DESCRIPTION
On my machine original code waited indefinetely long when polling for UDP socket data. So I rewrote the _check_nameserver by using dns.resolver.Resolver() class. Seems to be working well. For me it took ~2 minutes to propagate TXT entries.

There are also some minor aesthetic changes in log messages.